### PR TITLE
Bump cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.7.2)
 project(libffi C)
 
 set(SOURCES_LIST


### PR DESCRIPTION
Current version does not compile in latest versions of cmake where compatibility with < 3.5 has been removed